### PR TITLE
fix sketchy api calls

### DIFF
--- a/app/services/ApiService.ts
+++ b/app/services/ApiService.ts
@@ -96,25 +96,77 @@ export const putApiKeyFilter = (types?: HistoryType[]): Promise<HistoryType[]> =
 };
 
 // --- KYC --- //
-export const putKycData = (data: KycData, code?: string): Promise<KycInfo> => {
-  return fetchFrom<KycInfo>(`${KycUrl}/${code}/data`, "PUT", toKycDataDto(data));
-};
+export const putKycData = async (data: KycData, code?: string): Promise<KycInfo> => {
+  if (code === undefined) {
+    return await putKycDataOLD(data) as unknown as KycInfo
+  }
+  return await fetchFrom<KycInfo>(`${KycUrl}/${code}/data`, 'PUT', toKycDataDto(data))
+}
 
-export const postKyc = (code?: string): Promise<KycInfo> => {
-  return fetchFrom<KycInfo>(`${KycUrl}/${code}`, "POST");
-};
+export const postKyc = async (code?: string): Promise<KycInfo> => {
+  if (code === undefined) {
+    return await postKycOLD() as unknown as KycInfo
+  }
+  return await fetchFrom<KycInfo>(`${KycUrl}/${code}`, 'POST')
+}
 
-export const getKyc = (code?: string): Promise<KycInfo> => {
-  return fetchFrom<KycInfo>(`${KycUrl}/${code}`);
-};
+export const getKyc = async (code: string): Promise<KycInfo> => {
+  try {
+    return await fetchFrom<KycInfo>(`${KycUrl}/${code}`)
+  } catch (err) {
+    return await getKycOLD(code) as unknown as KycInfo
+  }
+}
 
-export const postLimit = (request: LimitRequest, code?: string): Promise<LimitRequest> => {
-  return fetchFrom<LimitRequest>(`${KycUrl}/${code}/limit`, "POST", request);
-};
+export const postLimit = async (request: LimitRequest, code?: string): Promise<LimitRequest> => {
+  if (code === undefined) {
+    return await postLimitOLD(request)
+  }
+  return await fetchFrom<LimitRequest>(`${KycUrl}/${code}/limit`, 'POST', request)
+}
 
-export const postFounderCertificate = (files: File[], code?: string): Promise<void> => {
-  return postFiles(`${KycUrl}/${code}/incorporationCertificate`, files);
-};
+export const postFounderCertificate = async (files: File[], code?: string): Promise<void> => {
+  if (code === undefined) {
+    return await postFounderCertificateOLD(files)
+  }
+  return await postFiles(`${KycUrl}/${code}/incorporationCertificate`, files)
+}
+
+// --- KYC @deprecated --- //
+/**
+ * @deprecated The method should not be used
+ */
+export const putKycDataOLD = async (data: KycData): Promise<void> => {
+  return await fetchFrom(`${KycUrl}/data`, 'POST', toKycDataDto(data))
+}
+
+/**
+ * @deprecated The method should not be used
+ */
+export const postKycOLD = async (): Promise<string> => {
+  return await fetchFrom<string>(KycUrl, 'POST')
+}
+
+/**
+ * @deprecated The method should not be used
+ */
+export const getKycOLD = async (code: string): Promise<KycResult> => {
+  return await fetchFrom<KycResult>(`${KycUrl}?code=${code}`)
+}
+
+/**
+ * @deprecated The method should not be used
+ */
+export const postLimitOLD = async (request: LimitRequest): Promise<LimitRequest> => {
+  return await fetchFrom<LimitRequest>(`${KycUrl}/limit`, 'POST', request)
+}
+
+/**
+ * @deprecated The method should not be used
+ */
+export const postFounderCertificateOLD = async (files: File[]): Promise<void> => {
+  return await postFiles(`${KycUrl}/incorporationCertificate`, files)
+}
 
 // --- VOTING --- //
 export const getSettings = (): Promise<Settings> => {


### PR DESCRIPTION
I stumbled over the current implementation of the kyc endpoints and saw that the `code` is optional.
Sure, could just be made non-optional or, like this PR, if code stays optional, just revert to old (deprecated) endpoints (also marked deprecated in implementation, but better reverting to deprecated than just plain failing).